### PR TITLE
fix: adjust the position of the execution program

### DIFF
--- a/build/dockerfile.bc-saas
+++ b/build/dockerfile.bc-saas
@@ -11,6 +11,9 @@ FROM alpine:3.16
 ARG ARCH=amd64
 ARG OS=linux
 
-COPY --from=0 /go/src/github.com/bestchains/bc-saas/_output/bin/${OS}/${ARCH}/* /bin/
 COPY --from=0 /go/src/github.com/bestchains/bc-saas/resource/ /bc-saas/resource/
-WORKDIR /bin
+COPY --from=0 /go/src/github.com/bestchains/bc-saas/_output/bin/${OS}/${ARCH}/* /bc-saas
+
+WORKDIR /bc-saas
+
+CMD ["./depository"]

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -29,7 +29,7 @@ spec:
         - name: depository
           image: hyperledgerk8s/bc-saas:6b0ed39
           command:
-            - depository
+            - ./depository
           args:
             - -v=5
             - -profile=/opt/depository/network.json


### PR DESCRIPTION
According to the default values of the depository parameters, the default is to look for images and font files in the same directory as the executable.

```shell
/bc-saas # ls -lh
total 124M   
-rwxr-xr-x    1 root     root       62.8M Jul  3 08:45 depository
-rwxr-xr-x    1 root     root       60.7M Jul  3 08:45 market
drwxr-xr-x    3 root     root          85 Jul  3 08:45 resource
```